### PR TITLE
Update 04-pushing-to-a-remote.md

### DIFF
--- a/labs/1.2-basic-git-commands/04-pushing-to-a-remote.md
+++ b/labs/1.2-basic-git-commands/04-pushing-to-a-remote.md
@@ -5,3 +5,5 @@ Now, push your local repository to this remote:
 ![Pushing to a remote](../../img/git-push.png)
  
 Notice how Git tells us that our local master branch is set up to track the remote master branch. This means that any subsequent pushes no longer need the `-u origin master` part. Just a `git push` will be enough.
+
+Note: if this fails double check that you are running the latest version of Git


### PR DESCRIPTION
tried this on an old widows image. it didn't work because in August 2021 GitHub stopped accepting password verification from the CLI. The new version of Git for Windows allows for the use of the credential helper or a code